### PR TITLE
needed for Ubuntu 21.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ sudo apt install \
   liblapack-dev \
   gfortran \
   libjpeg-dev \
+  python3-dev \
   zlib1g-dev
 
 wget https://github.com/Autodrop3d/BeltEngine/raw/main/dist/belt-engine-0.1.3.tar.gz


### PR DESCRIPTION
error was 
```
      triangle/core.c:4:10: fatal error: Python.h: No such file or directory
          4 | #include "Python.h"
            |          ^~~~~~~~~~
```
After change `pip3 install ./belt-engine-0.1.3.tar.gz` succeded.